### PR TITLE
Implementar listado paginado de Órdenes en /ordenes

### DIFF
--- a/src/app/features/ordenes/models/ordenes.model.ts
+++ b/src/app/features/ordenes/models/ordenes.model.ts
@@ -1,0 +1,32 @@
+export interface OrdenTrabajoListItemResponseDto {
+  id: number;
+  codigoOrden: string;
+  codigoSeguimientoPublico: string;
+  fechaIngreso: string;
+  estado: string;
+  clienteNombre: string;
+  telefonoPrincipal: string;
+  marcaNombre: string;
+  modeloNombre: string;
+  imeiSerie: string;
+  tecnicoNombre: string;
+}
+
+export interface PagedResponseDtoOrdenTrabajoListItemResponseDto {
+  content: OrdenTrabajoListItemResponseDto[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface OrdenesListQueryParams {
+  page: number;
+  size: number;
+  sort: string;
+  busqueda?: string;
+  estado?: string;
+  tecnicoId?: number;
+  fechaDesde?: string;
+  fechaHasta?: string;
+}

--- a/src/app/features/ordenes/ordenes.component.html
+++ b/src/app/features/ordenes/ordenes.component.html
@@ -1,0 +1,165 @@
+<section class="p-4 fade-view">
+  <app-page-header title="Órdenes" subtitle="Consultá y seguí el estado operativo de las órdenes de trabajo." />
+
+  <div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
+      <form [formGroup]="filtersForm" (ngSubmit)="aplicarFiltros()" class="row g-3 align-items-end">
+        <div class="col-12 col-xl-4">
+          <label class="form-label mb-1" for="busqueda">Búsqueda</label>
+          <input
+            id="busqueda"
+            type="text"
+            class="form-control"
+            formControlName="busqueda"
+            placeholder="Código, seguimiento, cliente, documento, teléfono, IMEI"
+          />
+        </div>
+
+        <div class="col-12 col-md-6 col-xl-2">
+          <label class="form-label mb-1" for="estado">Estado</label>
+          <input id="estado" type="text" class="form-control" formControlName="estado" placeholder="Ej: EN_REPARACION" />
+        </div>
+
+        <div class="col-12 col-md-6 col-xl-2">
+          <label class="form-label mb-1" for="tecnicoId">Técnico</label>
+          <select id="tecnicoId" class="form-select" formControlName="tecnicoId">
+            <option value="">Todos</option>
+            @for (tecnico of tecnicos(); track tecnico.id) {
+              <option [value]="tecnico.id">{{ tecnico.nombreCompleto }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="col-6 col-xl-2">
+          <label class="form-label mb-1" for="fechaDesde">Desde</label>
+          <input id="fechaDesde" type="date" class="form-control" formControlName="fechaDesde" />
+        </div>
+
+        <div class="col-6 col-xl-2">
+          <label class="form-label mb-1" for="fechaHasta">Hasta</label>
+          <input id="fechaHasta" type="date" class="form-control" formControlName="fechaHasta" />
+        </div>
+
+        <div class="col-12 d-flex gap-2 justify-content-end">
+          <button type="button" class="btn btn-outline-secondary" (click)="limpiarFiltros()" [disabled]="loading()">
+            <i class="bi bi-x-circle me-1"></i>
+            Limpiar
+          </button>
+          <button type="submit" class="btn btn-primary" [disabled]="loading()">
+            <i class="bi bi-search me-1"></i>
+            Buscar
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  @if (errorMessage()) {
+    <div class="alert alert-danger d-flex align-items-center justify-content-between gap-3" role="alert">
+      <span>{{ errorMessage() }}</span>
+      <button type="button" class="btn btn-sm btn-outline-danger" (click)="reintentar()">
+        <i class="bi bi-arrow-clockwise me-1"></i>
+        Reintentar
+      </button>
+    </div>
+  }
+
+  @if (loading()) {
+    <div class="card border-0 shadow-sm"><div class="card-body">Cargando órdenes...</div></div>
+  } @else if (!ordenes().length) {
+    <app-empty-state
+      title="No hay órdenes para los filtros aplicados"
+      description="Probá con otros criterios de búsqueda o limpiá los filtros para volver a consultar."
+    />
+  } @else {
+    <div class="card border-0 shadow-sm">
+      <div class="table-responsive">
+        <table class="table table-hover align-middle mb-0">
+          <thead class="table-light">
+            <tr>
+              <th>
+                <button type="button" class="btn btn-link btn-sort" (click)="toggleSort('codigoOrden')">
+                  Código
+                  <i class="bi" [ngClass]="sortIconFor('codigoOrden')"></i>
+                </button>
+              </th>
+              <th>Seguimiento</th>
+              <th>
+                <button type="button" class="btn btn-link btn-sort" (click)="toggleSort('fechaIngreso')">
+                  Fecha ingreso
+                  <i class="bi" [ngClass]="sortIconFor('fechaIngreso')"></i>
+                </button>
+              </th>
+              <th>
+                <button type="button" class="btn btn-link btn-sort" (click)="toggleSort('estado')">
+                  Estado
+                  <i class="bi" [ngClass]="sortIconFor('estado')"></i>
+                </button>
+              </th>
+              <th>
+                <button type="button" class="btn btn-link btn-sort" (click)="toggleSort('clienteNombre')">
+                  Cliente
+                  <i class="bi" [ngClass]="sortIconFor('clienteNombre')"></i>
+                </button>
+              </th>
+              <th>Teléfono</th>
+              <th>Marca</th>
+              <th>Modelo</th>
+              <th>IMEI/Serie</th>
+              <th>
+                <button type="button" class="btn btn-link btn-sort" (click)="toggleSort('tecnicoNombre')">
+                  Técnico
+                  <i class="bi" [ngClass]="sortIconFor('tecnicoNombre')"></i>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (orden of ordenes(); track orden.id) {
+              <tr>
+                <td>{{ orden.codigoOrden }}</td>
+                <td>{{ orden.codigoSeguimientoPublico || '-' }}</td>
+                <td>{{ orden.fechaIngreso | date: 'dd/MM/yyyy' }}</td>
+                <td><span class="badge text-bg-light border">{{ orden.estado }}</span></td>
+                <td>{{ orden.clienteNombre }}</td>
+                <td>{{ orden.telefonoPrincipal || '-' }}</td>
+                <td>{{ orden.marcaNombre || '-' }}</td>
+                <td>{{ orden.modeloNombre || '-' }}</td>
+                <td>{{ orden.imeiSerie || '-' }}</td>
+                <td>{{ orden.tecnicoNombre || '-' }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+
+      <div class="card-footer bg-white d-flex flex-wrap gap-3 justify-content-between align-items-center">
+        <small class="text-muted">
+          Mostrando {{ rangeStart() }} - {{ rangeEnd() }} de {{ totalElements() }} órdenes
+        </small>
+
+        <div class="d-flex align-items-center gap-2 flex-wrap justify-content-end">
+          <label for="pageSize" class="small text-muted">Tamaño</label>
+          <select id="pageSize" class="form-select form-select-sm page-size" [value]="size()" (change)="onPageSizeChange($event)">
+            <option value="10">10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+          </select>
+
+          <button type="button" class="btn btn-outline-secondary btn-sm" (click)="goToPage(page() - 1)" [disabled]="page() === 0">
+            <i class="bi bi-chevron-left"></i>
+          </button>
+          <span class="small text-muted">Página {{ page() + 1 }} de {{ totalPages() || 1 }}</span>
+          <button
+            type="button"
+            class="btn btn-outline-secondary btn-sm"
+            (click)="goToPage(page() + 1)"
+            [disabled]="page() + 1 >= totalPages()"
+          >
+            <i class="bi bi-chevron-right"></i>
+          </button>
+        </div>
+      </div>
+    </div>
+  }
+</section>

--- a/src/app/features/ordenes/ordenes.component.scss
+++ b/src/app/features/ordenes/ordenes.component.scss
@@ -1,0 +1,11 @@
+.btn-sort {
+  --bs-btn-padding-y: 0;
+  --bs-btn-padding-x: 0;
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-font-weight: 600;
+  text-decoration: none;
+}
+
+.page-size {
+  width: 84px;
+}

--- a/src/app/features/ordenes/ordenes.component.ts
+++ b/src/app/features/ordenes/ordenes.component.ts
@@ -1,18 +1,263 @@
-import { Component } from '@angular/core';
-import { FeaturePlaceholderComponent } from '../../shared/components/feature-placeholder/feature-placeholder.component';
+import { DatePipe, NgClass } from '@angular/common';
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
+import { PageHeaderComponent } from '../../shared/components/page-header/page-header.component';
+import { TecnicoDropdownResponseDto } from '../../shared/models/dropdown.model';
+import { TecnicosDropdownService } from '../../shared/services/tecnicos-dropdown.service';
+import { OrdenTrabajoListItemResponseDto } from './models/ordenes.model';
+import { OrdenesApiService } from './services/ordenes-api.service';
+
+type SortableField = 'codigoOrden' | 'fechaIngreso' | 'estado' | 'clienteNombre' | 'tecnicoNombre';
+type SortDirection = 'asc' | 'desc';
+
+interface ListState {
+  page: number;
+  size: number;
+  sort: string;
+  busqueda?: string;
+  estado?: string;
+  tecnicoId?: number;
+  fechaDesde?: string;
+  fechaHasta?: string;
+}
+
+const DEFAULT_STATE: ListState = {
+  page: 0,
+  size: 20,
+  sort: 'fechaIngreso,desc'
+};
 
 @Component({
   selector: 'app-ordenes',
   standalone: true,
-  imports: [FeaturePlaceholderComponent],
-  template: `<app-feature-placeholder [title]="title" [summary]="summary" [nextSteps]="nextSteps" />`
+  imports: [ReactiveFormsModule, DatePipe, NgClass, PageHeaderComponent, EmptyStateComponent],
+  templateUrl: './ordenes.component.html',
+  styleUrl: './ordenes.component.scss'
 })
-export class OrdenesComponent {
-  readonly title = 'Órdenes';
-  readonly summary = 'Gestión completa de órdenes de trabajo desde recepción hasta entrega.';
-  readonly nextSteps = [
-    'Crear flujo de estados interno para la orden.',
-    'Registrar diagnóstico técnico y responsable.',
-    'Bloquear avance a reparación sin presupuesto emitido.'
-  ];
+export class OrdenesComponent implements OnInit {
+  private readonly ordenesApi = inject(OrdenesApiService);
+  private readonly tecnicosDropdownService = inject(TecnicosDropdownService);
+  private readonly fb = inject(FormBuilder);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+
+  protected readonly loading = signal(false);
+  protected readonly errorMessage = signal('');
+  protected readonly ordenes = signal<OrdenTrabajoListItemResponseDto[]>([]);
+  protected readonly tecnicos = signal<TecnicoDropdownResponseDto[]>([]);
+
+  protected readonly page = signal(DEFAULT_STATE.page);
+  protected readonly size = signal(DEFAULT_STATE.size);
+  protected readonly totalElements = signal(0);
+  protected readonly totalPages = signal(0);
+  protected readonly sort = signal(DEFAULT_STATE.sort);
+
+  protected readonly filtersForm = this.fb.nonNullable.group({
+    busqueda: '',
+    estado: '',
+    tecnicoId: '',
+    fechaDesde: '',
+    fechaHasta: ''
+  });
+
+  ngOnInit(): void {
+    const stateFromUrl = this.readStateFromUrl();
+    this.patchForm(stateFromUrl);
+    this.page.set(stateFromUrl.page);
+    this.size.set(stateFromUrl.size);
+    this.sort.set(stateFromUrl.sort);
+
+    this.cargarTecnicos();
+    this.cargarOrdenes(stateFromUrl);
+  }
+
+  protected aplicarFiltros(): void {
+    this.updateRouteAndLoad({ page: 0 });
+  }
+
+  protected limpiarFiltros(): void {
+    this.filtersForm.reset({
+      busqueda: '',
+      estado: '',
+      tecnicoId: '',
+      fechaDesde: '',
+      fechaHasta: ''
+    });
+
+    this.updateRouteAndLoad({
+      page: 0,
+      size: DEFAULT_STATE.size,
+      sort: DEFAULT_STATE.sort
+    });
+  }
+
+  protected reintentar(): void {
+    this.updateRouteAndLoad();
+  }
+
+  protected toggleSort(field: SortableField): void {
+    const [currentField, currentDirection] = this.sort().split(',') as [SortableField, SortDirection];
+    const nextDirection: SortDirection =
+      currentField === field && currentDirection === 'asc' ? 'desc' : 'asc';
+
+    this.updateRouteAndLoad({ page: 0, sort: `${field},${nextDirection}` });
+  }
+
+  protected sortIconFor(field: SortableField): string {
+    const [currentField, currentDirection] = this.sort().split(',') as [SortableField, SortDirection];
+
+    if (currentField !== field) {
+      return 'bi-arrow-down-up';
+    }
+
+    return currentDirection === 'asc' ? 'bi-sort-alpha-down' : 'bi-sort-alpha-up';
+  }
+
+  protected goToPage(nextPage: number): void {
+    if (nextPage < 0 || nextPage >= this.totalPages()) {
+      return;
+    }
+
+    this.updateRouteAndLoad({ page: nextPage });
+  }
+
+  protected onPageSizeChange(event: Event): void {
+    const nextSize = Number((event.target as HTMLSelectElement).value);
+    this.updateRouteAndLoad({ page: 0, size: nextSize });
+  }
+
+  protected rangeStart(): number {
+    if (!this.totalElements()) {
+      return 0;
+    }
+
+    return this.page() * this.size() + 1;
+  }
+
+  protected rangeEnd(): number {
+    if (!this.totalElements()) {
+      return 0;
+    }
+
+    return Math.min((this.page() + 1) * this.size(), this.totalElements());
+  }
+
+  private cargarTecnicos(): void {
+    this.tecnicosDropdownService.listarTecnicosActivos().subscribe({
+      next: (items) => this.tecnicos.set(items),
+      error: () => this.tecnicos.set([])
+    });
+  }
+
+  private updateRouteAndLoad(overrides: Partial<ListState> = {}): void {
+    const nextState = { ...this.currentStateFromControls(), ...overrides };
+
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: this.toQueryParams(nextState)
+    });
+
+    this.cargarOrdenes(nextState);
+  }
+
+  private cargarOrdenes(state: ListState): void {
+    this.loading.set(true);
+    this.errorMessage.set('');
+
+    this.ordenesApi.listar(state).subscribe({
+      next: (response) => {
+        this.ordenes.set(response.content);
+        this.page.set(response.page);
+        this.size.set(response.size);
+        this.totalElements.set(response.totalElements);
+        this.totalPages.set(response.totalPages);
+        this.sort.set(state.sort);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.errorMessage.set('No fue posible cargar el listado de órdenes.');
+        this.ordenes.set([]);
+        this.totalElements.set(0);
+        this.totalPages.set(0);
+        this.loading.set(false);
+      }
+    });
+  }
+
+  private currentStateFromControls(): ListState {
+    const raw = this.filtersForm.getRawValue();
+    const tecnicoId = raw.tecnicoId ? Number(raw.tecnicoId) : undefined;
+
+    return {
+      page: this.page(),
+      size: this.size(),
+      sort: this.sort(),
+      busqueda: raw.busqueda.trim() || undefined,
+      estado: raw.estado.trim() || undefined,
+      tecnicoId,
+      fechaDesde: raw.fechaDesde || undefined,
+      fechaHasta: raw.fechaHasta || undefined
+    };
+  }
+
+  private readStateFromUrl(): ListState {
+    const query = this.route.snapshot.queryParamMap;
+    const page = Number(query.get('page'));
+    const size = Number(query.get('size'));
+    const sort = query.get('sort') || DEFAULT_STATE.sort;
+    const tecnicoIdParam = query.get('tecnicoId');
+
+    return {
+      page: Number.isInteger(page) && page >= 0 ? page : DEFAULT_STATE.page,
+      size: Number.isInteger(size) && size > 0 ? size : DEFAULT_STATE.size,
+      sort,
+      busqueda: query.get('busqueda') || undefined,
+      estado: query.get('estado') || undefined,
+      tecnicoId: tecnicoIdParam ? Number(tecnicoIdParam) : undefined,
+      fechaDesde: query.get('fechaDesde') || undefined,
+      fechaHasta: query.get('fechaHasta') || undefined
+    };
+  }
+
+  private patchForm(state: ListState): void {
+    this.filtersForm.patchValue({
+      busqueda: state.busqueda ?? '',
+      estado: state.estado ?? '',
+      tecnicoId: state.tecnicoId ? String(state.tecnicoId) : '',
+      fechaDesde: state.fechaDesde ?? '',
+      fechaHasta: state.fechaHasta ?? ''
+    });
+  }
+
+  private toQueryParams(state: ListState): Record<string, string | number> {
+    const params: Record<string, string | number> = {
+      page: state.page,
+      size: state.size,
+      sort: state.sort
+    };
+
+    if (state.busqueda) {
+      params['busqueda'] = state.busqueda;
+    }
+
+    if (state.estado) {
+      params['estado'] = state.estado;
+    }
+
+    if (state.tecnicoId !== undefined) {
+      params['tecnicoId'] = state.tecnicoId;
+    }
+
+    if (state.fechaDesde) {
+      params['fechaDesde'] = state.fechaDesde;
+    }
+
+    if (state.fechaHasta) {
+      params['fechaHasta'] = state.fechaHasta;
+    }
+
+    return params;
+  }
 }

--- a/src/app/features/ordenes/services/ordenes-api.service.ts
+++ b/src/app/features/ordenes/services/ordenes-api.service.ts
@@ -1,0 +1,44 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { API_BASE_URL } from '../../../core/config/api-base-url.token';
+import {
+  OrdenesListQueryParams,
+  PagedResponseDtoOrdenTrabajoListItemResponseDto
+} from '../models/ordenes.model';
+
+@Injectable({ providedIn: 'root' })
+export class OrdenesApiService {
+  private readonly http = inject(HttpClient);
+  private readonly apiBaseUrl = inject(API_BASE_URL);
+  private readonly baseUrl = `${this.apiBaseUrl}/api/ordenes`;
+
+  listar(params: OrdenesListQueryParams): Observable<PagedResponseDtoOrdenTrabajoListItemResponseDto> {
+    let httpParams = new HttpParams()
+      .set('page', params.page)
+      .set('size', params.size)
+      .set('sort', params.sort);
+
+    if (params.busqueda) {
+      httpParams = httpParams.set('busqueda', params.busqueda);
+    }
+
+    if (params.estado) {
+      httpParams = httpParams.set('estado', params.estado);
+    }
+
+    if (params.tecnicoId !== undefined) {
+      httpParams = httpParams.set('tecnicoId', params.tecnicoId);
+    }
+
+    if (params.fechaDesde) {
+      httpParams = httpParams.set('fechaDesde', params.fechaDesde);
+    }
+
+    if (params.fechaHasta) {
+      httpParams = httpParams.set('fechaHasta', params.fechaHasta);
+    }
+
+    return this.http.get<PagedResponseDtoOrdenTrabajoListItemResponseDto>(this.baseUrl, { params: httpParams });
+  }
+}


### PR DESCRIPTION
### Motivation
- Entregar la pantalla real de listado de órdenes que consuma el backend existente y reemplace el placeholder anterior. 
- Soportar búsqueda, filtros básicos, paginación y ordenamiento server-side según el contrato API definido. 
- Mantener la integración visual y componentes compartidos del proyecto (tema Simplex, `PageHeader`, `EmptyState`, diseño de layout).

### Description
- Añadí modelos alineados al contrato en `src/app/features/ordenes/models/ordenes.model.ts` y un servicio HTTP `OrdenesApiService` en `src/app/features/ordenes/services/ordenes-api.service.ts` que consulta `GET /api/ordenes` usando `HttpParams` para `page`, `size`, `sort`, `busqueda`, `estado`, `tecnicoId`, `fechaDesde` y `fechaHasta`.
- Reemplacé el placeholder por un componente de listado real en `src/app/features/ordenes/ordenes.component.ts` con plantilla en `src/app/features/ordenes/ordenes.component.html` y estilos en `src/app/features/ordenes/ordenes.component.scss`, implementando toolbar de filtros reactiva, tablas con columnas requeridas y mapping de clicks de encabezado a `sort` (ej.: `fechaIngreso,desc`).
- Integro el dropdown de técnicos reutilizando `TecnicosDropdownService` (`GET /api/tecnicos/dropdown`) para poblar el filtro `tecnicoId`, y reutilicé `PageHeaderComponent` y `EmptyStateComponent` para mantener consistencia visual.
- Implementé estados de pantalla (`loading`, `empty`, `error`), paginación remota con tamaños `10/20/50` (por defecto `20`), sincronización simple de estado en la URL (query params) y no añadí acciones por fila que no estén soportadas por el backend.

### Testing
- Ejecuté `npm run build` y la compilación terminó correctamente sin errores de compilación (hubo warnings de budget/CSS preexistentes que no bloquean el build). 
- No se ejecutaron pruebas unitarias automatizadas adicionales dentro de este cambio. 
- Archivos creados/modificados verificados: `src/app/features/ordenes/ordenes.component.ts`, `src/app/features/ordenes/ordenes.component.html`, `src/app/features/ordenes/ordenes.component.scss`, `src/app/features/ordenes/models/ordenes.model.ts`, `src/app/features/ordenes/services/ordenes-api.service.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb22810a4832f8931d40c5f60f8c3)